### PR TITLE
NO-JIRA: Fix build for library users

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,12 @@
 const std = @import("std");
 
+const log = std.log.scoped(.aeron);
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    if (target.result.cpu.arch != .x86_64) @panic("The target CPU architecture needs to be 'x86_64'");
+    if (target.result.cpu.arch != .x86_64) log.err("The target CPU architecture needs to be 'x86_64': {s}", .{@tagName(target.result.cpu.arch)});
 
     const options = b.addOptions();
     const dynamic = b.option(bool, "dynamic", "link with dynamic library (default: false)") orelse false;
@@ -17,9 +19,11 @@ pub fn build(b: *std.Build) void {
     });
 
     lib.addLibraryPath(b.path("lib"));
-    switch (target.result.abi) {
-        .gnu => lib.linkSystemLibrary(if (dynamic) "aeron_libc" else "aeron_static_libc", .{}),
-        .musl => lib.linkSystemLibrary(if (dynamic) "aeron_musl" else "aeron_static_musl", .{}),
-        else => @panic("The target ABI needs to be 'musl' or 'gnu'"),
+    if (target.result.cpu.arch == .x86_64) {
+        switch (target.result.abi) {
+            .gnu => lib.linkSystemLibrary(if (dynamic) "aeron_libc" else "aeron_static_libc", .{}),
+            .musl => lib.linkSystemLibrary(if (dynamic) "aeron_musl" else "aeron_static_musl", .{}),
+            else => |abi| log.err("The target ABI needs to be 'musl' or 'gnu': {s}", .{@tagName(abi)}),
+        }
     }
 }


### PR DESCRIPTION
Do not quit if the CPU and ABI does not match with the required ones,
because the IDE will not recognize the referenced modules on other
architectures (like Apple silicon).